### PR TITLE
Clutter::init(): return the ClutterInitError value

### DIFF
--- a/lib/Clutter.pm
+++ b/lib/Clutter.pm
@@ -37,12 +37,12 @@ sub Clutter::check_version {
 }
 
 sub Clutter::init {
-    my $rest = Glib::Object::Introspection->invoke(
+    my ($error, $rest) = Glib::Object::Introspection->invoke(
         $_CLUTTER_BASENAME, undef, 'init',
         [$0, @ARGV],
     );
     @ARGV = @{$rest}[1 .. $#$rest]; # remove $0
-    return;
+    return $error;
 }
 
 sub Clutter::main {


### PR DESCRIPTION
This allows the API consumer to check if Clutter has
been initialised properly.

Also filed as <https://bugzilla.gnome.org/show_bug.cgi?id=773498>.